### PR TITLE
Issue #2636510 by Boobaa: Added upgrade path from Drupal 6 to 8.

### DIFF
--- a/migration_templates/migrate.migration.geshifilter_settings.yml
+++ b/migration_templates/migrate.migration.geshifilter_settings.yml
@@ -1,6 +1,7 @@
 id: d7_geshifilter_settings
 label: GeshiFilter
 migration_tags:
+  - Drupal 6
   - Drupal 7
 source:
   plugin: variable


### PR DESCRIPTION
A simple rename and adding the `Drupal 6` migration tag does the trick. Tested manually on my local and seems to work great.